### PR TITLE
admin/fix-ci-and-upgrade-lint-dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,23 +2,23 @@ files: bioio
 repos:
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.2.0
     hooks:
       - id: autoflake
         args: ["--in-place", "--remove-all-unused-imports"]
 
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.3.0
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         additional_dependencies:
@@ -26,6 +26,6 @@ repos:
           - flake8-pyprojecttoml
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v1.4.1
     hooks:
       - id: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,14 +41,6 @@ Documentation = "https://bioio-devs.github.io/bioio"
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
 lint = [
-  "black>=22.3.0",
-  "check-manifest>=0.48",
-  "flake8>=3.8.3",
-  "flake8-debugger>=3.2.1",
-  "flake8-pyprojecttoml",
-  "flake8-typing-imports>=1.9.0",
-  "isort>=5.7.0",
-  "mypy>=0.790",
   "pre-commit>=2.20.0",
 ]
 test = [


### PR DESCRIPTION
### Description of Changes

The CI was failing due to an issue with `isort` and `poetry`, upgrading `isort` to `>5.12.0` fixes this issue. Beyond that I noticed the versions were specified in both `.pre-commit-config.yaml` & `pyproject.toml`, it doesn't appear that `pre-commit` requires any of these dependencies to be installed prior to running `pre-commit` based on it ignoring whatever version I specify in `pyproject.toml` and solely using the version specified by the `rev` in the `pre-commit-config.yaml`. I tested this on MacOS as described below, but if I'm missing the value of `pyproject.toml` having the versions too let me know!

### Testing
Created a fresh virtual environment, installed dependencies, and ran `just lint` & `just test`
