### PR TITLE
use correct package name for bioio-base

### DIFF
--- a/bioio/plugins.py
+++ b/bioio/plugins.py
@@ -22,7 +22,7 @@ from bioio_base.reader_metadata import ReaderMetadata
 ###############################################################################
 
 BIOIO_DIST_NAME = "bioio"
-BIOIO_BASE_DIST_NAME = "bioio-base"  # TODO: Rename to bioio-base
+BIOIO_BASE_DIST_NAME = "bioio-base"
 
 
 class PluginEntry(NamedTuple):

--- a/bioio/plugins.py
+++ b/bioio/plugins.py
@@ -22,7 +22,7 @@ from bioio_base.reader_metadata import ReaderMetadata
 ###############################################################################
 
 BIOIO_DIST_NAME = "bioio"
-BIOIO_BASE_DIST_NAME = "bioio-types"  # TODO: Rename to bioio-base
+BIOIO_BASE_DIST_NAME = "bioio-base"  # TODO: Rename to bioio-base
 
 
 class PluginEntry(NamedTuple):


### PR DESCRIPTION
I think we can't really use bioio without this change. This is required for get_plugins to work, and get_plugins is currently reqiured in order to have any file format support.

