### PR TITLE
Allow '.' in plugin ext prefix

### DIFF
--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -150,6 +150,9 @@ class BioImage(biob.image_container.ImageContainer):
 
             # Check for extension in plugins_by_ext
             for format_ext, plugins in plugins_by_ext.items():
+                # Remove "." prefix if already there
+                if format_ext.startswith("."):
+                    format_ext = format_ext[1:]
                 if path.lower().endswith(f".{format_ext}"):
                     for plugin in plugins:
                         ReaderClass = plugin.metadata.get_reader()


### PR DESCRIPTION
Seems we weren't consistent in the plugins about whether or not we should have the extensions include or exclude the  "." prefix. This change makes either work.