### PR TITLE
bugfix/longest-suffix-wins

### DIFF
--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -164,9 +164,6 @@ class BioImage(biob.image_container.ImageContainer):
 
             # Check for extension in plugins_by_ext
             for format_ext, plugins in plugins_by_ext.items():
-                # Remove "." prefix if already there
-                if format_ext.startswith("."):
-                    format_ext = format_ext[1:]
                 if path.lower().endswith(f".{format_ext}"):
                     for plugin in plugins:
                         ReaderClass = plugin.metadata.get_reader()

--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -164,7 +164,7 @@ class BioImage(biob.image_container.ImageContainer):
 
             # Check for extension in plugins_by_ext
             for format_ext, plugins in plugins_by_ext.items():
-                if path.lower().endswith(f".{format_ext}"):
+                if path.lower().endswith(format_ext):
                     for plugin in plugins:
                         ReaderClass = plugin.metadata.get_reader()
                         try:

--- a/bioio/plugins.py
+++ b/bioio/plugins.py
@@ -17,7 +17,7 @@ else:
     from importlib.metadata import entry_points, EntryPoint, requires
 
 import time
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import Dict, List, NamedTuple, Optional, Tuple, Union
 
 from bioio_base.reader import Reader
 from bioio_base.reader_metadata import ReaderMetadata
@@ -38,9 +38,9 @@ class PluginEntry(NamedTuple):
 
 
 # global cache of plugins
-plugins_by_ext_cache: (
-    Dict[str, List[PluginEntry]] | OrderedDict[str, List[PluginEntry]]
-) = {}
+plugins_by_ext_cache: Union[
+    Dict[str, List[PluginEntry]], OrderedDict[str, List[PluginEntry]]
+] = {}
 
 
 def check_type(image: ImageLike, reader_class: Reader) -> bool:

--- a/bioio/plugins.py
+++ b/bioio/plugins.py
@@ -7,7 +7,6 @@ import sys
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
-from pprint import pprint
 from typing import get_args
 
 import semver
@@ -231,7 +230,6 @@ def get_plugins(use_cache: bool) -> Dict[str, List[PluginEntry]]:
                 # And worse can cause this plugin list to have multiple entries
                 # for the same extension (e.g. ".tif" and "tif")
                 if ext.startswith("."):
-                    print(f"Plugin: {plugin_entry} includes leading '.' in ext: {ext}")
                     ext = ext[1:]
 
                 # Start a new list of plugins for ext if it doesn't exist
@@ -242,12 +240,6 @@ def get_plugins(use_cache: bool) -> Dict[str, List[PluginEntry]]:
                 # insert in sorted order (sorted by most recently installed)
                 pluginlist = plugins_by_ext[ext]
                 insert_sorted_by_timestamp(pluginlist, plugin_entry)
-
-    print("Before sorting:")
-    pprint(plugins_by_ext)
-
-    print()
-    print()
 
     # Dictionary values (the lists of plugin entries) have already been sorted
     # by timestamp due to the "insert_sorted_by_timestamp" function
@@ -264,9 +256,6 @@ def get_plugins(use_cache: bool) -> Dict[str, List[PluginEntry]]:
             reverse=True,
         )
     )
-
-    print("After sorting:")
-    pprint(plugins_by_ext)
 
     # Save copy of plugins to cache then return
     plugins_by_ext_cache.clear()

--- a/bioio/plugins.py
+++ b/bioio/plugins.py
@@ -233,6 +233,11 @@ def get_plugins(use_cache: bool) -> Dict[str, List[PluginEntry]]:
     # Save copy of plugins to cache then return
     plugins_by_ext_cache.clear()
     plugins_by_ext_cache.update(plugins_by_ext)
+
+    # Sort dict from longest to shortest key
+    plugins_by_ext = dict(
+        sorted(plugins_by_ext.items(), key=lambda x: len(x[0]), reverse=True)
+    )
     return plugins_by_ext
 
 

--- a/bioio/plugins.py
+++ b/bioio/plugins.py
@@ -17,7 +17,7 @@ else:
     from importlib.metadata import entry_points, EntryPoint, requires
 
 import time
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Dict, List, NamedTuple, Optional, Tuple
 
 from bioio_base.reader import Reader
 from bioio_base.reader_metadata import ReaderMetadata
@@ -38,9 +38,7 @@ class PluginEntry(NamedTuple):
 
 
 # global cache of plugins
-plugins_by_ext_cache: Union[
-    Dict[str, List[PluginEntry]], OrderedDict[str, List[PluginEntry]]
-] = {}
+plugins_by_ext_cache: OrderedDict[str, List[PluginEntry]] = OrderedDict()
 
 
 def check_type(image: ImageLike, reader_class: Reader) -> bool:
@@ -225,12 +223,9 @@ def get_plugins(use_cache: bool) -> Dict[str, List[PluginEntry]]:
             # Add plugin entry
             plugin_entry = PluginEntry(plugin, reader_meta, timestamp)
             for ext in plugin_entry.metadata.get_supported_extensions():
-                # Always remove leading "." if there is one
-                # Some plugin authors may add it, but it's not necessary
-                # And worse can cause this plugin list to have multiple entries
-                # for the same extension (e.g. ".tif" and "tif")
-                if ext.startswith("."):
-                    ext = ext[1:]
+                ext = ext.lower()
+                if not ext.startswith("."):
+                    ext = "." + ext
 
                 # Start a new list of plugins for ext if it doesn't exist
                 if ext not in plugins_by_ext:


### PR DESCRIPTION
…ost specific plugins are matched first

<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #54 

### Description of Changes

<!-- Include a description of the proposed changes. -->

Sort the list of plugins by suffix length prior to determining the plugin reader to ensure we find the most specific viable readers first