### PR TITLE
bugfix/correct-version-in-doc-builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # We use https://pypi.org/project/setuptools-scm/ for dynamic lib versioning
+          # Without our tagged versions, it defaults to 0.1.dev*
+          fetch-tags: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #58 

### Description of Changes

<!-- Include a description of the proposed changes. -->

I _think_ this is the fix for #58.

My thinking here is that, because we use [setuptools-scm](https://pypi.org/project/setuptools-scm/) to allow the package to be versioned by git tags, we need to give the tag information to the doc CI build prior to package install as well.

The reason that the publish job doesn't need this info is that it only runs on _tag releases_ already.

If my assumptions are correct, the doc versions should now follow the package version BUT will likely still have the dev* bit at the end. That is, when this is merged it should be something like `1.0.4.dev1+g06fa7f2` which is the version I get when I install locally on my #55 branch. If we don't want that dev bit, we will likely need to only run this doc build job on tag releases.