### PR TITLE
Support public s3 files automatically

### DIFF
--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -255,6 +255,35 @@ class BioImage(biob.image_container.ImageContainer):
             ),
         )
 
+    @staticmethod
+    def _get_reader(
+        image: biob.types.ImageLike,
+        reader: biob.reader.Reader,
+        use_plugin_cache: bool,
+        fs_kwargs: Dict[str, Any],
+        **kwargs: Any,
+    ) -> Tuple[biob.reader.Reader, Optional[PluginEntry]]:
+        """
+        Initializes and returns the reader (and plugin if relevant) for the provided
+        image based on provided args and/or the available bioio supported plugins
+        """
+        if reader is not None:
+            # Check specific reader image types in a situation where a specified reader
+            # only supports some of the ImageLike types.
+            if not check_type(image, reader):
+                raise biob.exceptions.UnsupportedFileFormatError(
+                    reader.__name__, str(type(image))
+                )
+
+            return reader(image, fs_kwargs=fs_kwargs, **kwargs), None
+
+        # Determine reader class based on available plugins
+        plugin = BioImage.determine_plugin(
+            image, fs_kwargs=fs_kwargs, use_plugin_cache=use_plugin_cache, **kwargs
+        )
+        ReaderClass = plugin.metadata.get_reader()
+        return ReaderClass(image, fs_kwargs=fs_kwargs, **kwargs), plugin
+
     def __init__(
         self,
         image: biob.types.ImageLike,
@@ -264,25 +293,27 @@ class BioImage(biob.image_container.ImageContainer):
         fs_kwargs: Dict[str, Any] = {},
         **kwargs: Any,
     ):
-        if reader is None:
-            # Determine reader class and create dask delayed array
-            self._plugin = BioImage.determine_plugin(
-                image, fs_kwargs=fs_kwargs, use_plugin_cache=use_plugin_cache, **kwargs
+        try:
+            self._reader, self._plugin = self._get_reader(
+                image,
+                reader,
+                use_plugin_cache,
+                fs_kwargs,
+                **kwargs,
             )
-            ReaderClass = self._plugin.metadata.get_reader()
-        else:
-            # check specific reader image types in a situation where a specified reader
-            # only supports some of the ImageLike types.
-            if not check_type(image, reader):
-                raise biob.exceptions.UnsupportedFileFormatError(
-                    reader.__name__, str(type(image))
+        except biob.exceptions.UnsupportedFileFormatError:
+            # When reading from S3 if we failed trying to read
+            # try reading as an anonymous user
+            if image.startswith("s3://"):
+                self._reader, self._plugin = self._get_reader(
+                    image,
+                    reader,
+                    use_plugin_cache,
+                    fs_kwargs | {"anon": True},
+                    **kwargs,
                 )
 
-            # connect submitted reader
-            ReaderClass = reader
-
-        # Init and store reader
-        self._reader = ReaderClass(image, fs_kwargs=fs_kwargs, **kwargs)
+            raise
 
         # Store delayed modifiers
         self._reconstruct_mosaic = reconstruct_mosaic
@@ -1097,13 +1128,16 @@ class BioImage(biob.image_container.ImageContainer):
         )
 
     def __str__(self) -> str:
-        return (
-            f"<BioImage ["
-            f"plugin: {self._plugin.entrypoint.name} installed "
-            f"at {datetime.datetime.fromtimestamp(self._plugin.timestamp)}, "
-            f"Image-is-in-Memory: {self._xarray_data is not None}"
-            f"]>"
-        )
+        if self._plugin is not None:
+            return (
+                f"<BioImage ["
+                f"plugin: {self._plugin.entrypoint.name} installed "
+                f"at {datetime.datetime.fromtimestamp(self._plugin.timestamp)}, "
+                f"Image-is-in-Memory: {self._xarray_data is not None}"
+                f"]>"
+            )
+
+        return "<BioImage [Image-is-in-Memory: {self._xarray_data is not None}]>"
 
     def __repr__(self) -> str:
         return str(self)

--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -1137,7 +1137,7 @@ class BioImage(biob.image_container.ImageContainer):
                 f"]>"
             )
 
-        return "<BioImage [Image-is-in-Memory: {self._xarray_data is not None}]>"
+        return f"<BioImage [Image-is-in-Memory: {self._xarray_data is not None}]>"
 
     def __repr__(self) -> str:
         return str(self)

--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -303,17 +303,18 @@ class BioImage(biob.image_container.ImageContainer):
             )
         except biob.exceptions.UnsupportedFileFormatError:
             # When reading from S3 if we failed trying to read
-            # try reading as an anonymous user
-            if image.startswith("s3://"):
-                self._reader, self._plugin = self._get_reader(
-                    image,
-                    reader,
-                    use_plugin_cache,
-                    fs_kwargs | {"anon": True},
-                    **kwargs,
-                )
+            # try reading as an anonymous user otherwise re-raise
+            # the error
+            if not str(image).startswith("s3://"):
+                raise
 
-            raise
+            self._reader, self._plugin = self._get_reader(
+                image,
+                reader,
+                use_plugin_cache,
+                fs_kwargs | {"anon": True},
+                **kwargs,
+            )
 
         # Store delayed modifiers
         self._reconstruct_mosaic = reconstruct_mosaic

--- a/bioio/tests/conftest.py
+++ b/bioio/tests/conftest.py
@@ -36,10 +36,12 @@ log = logging.getLogger(__name__)
 
 
 @pytest.fixture
-def sample_text_file(tmp_path: pathlib.Path) -> pathlib.Path:
+def sample_text_file(
+    tmp_path: pathlib.Path,
+) -> typing.Generator[pathlib.Path, None, None]:
     example_file = tmp_path / "temp-example.txt"
     example_file.write_text("just some example text here")
-    return example_file
+    yield example_file
 
 
 def np_random_from_shape(
@@ -90,3 +92,9 @@ class InstallPackage:
         subprocess.check_call(
             [sys.executable, "-m", "pip", "uninstall", "-y", self.package_name]
         )
+
+
+@pytest.fixture
+def dummy_plugin() -> typing.Generator[str, None, None]:
+    with InstallPackage(package_path=DUMMY_PLUGIN_PATH, package_name=DUMMY_PLUGIN_NAME):
+        yield DUMMY_PLUGIN_NAME

--- a/bioio/tests/test_plugins.py
+++ b/bioio/tests/test_plugins.py
@@ -9,33 +9,32 @@ import numpy as np
 import bioio
 
 from ..plugins import dump_plugins
-from .conftest import DUMMY_PLUGIN_NAME, DUMMY_PLUGIN_PATH, InstallPackage
 
 
-def test_dump_plugins() -> None:
-    with InstallPackage(package_path=DUMMY_PLUGIN_PATH, package_name=DUMMY_PLUGIN_NAME):
-        # Capture the output of dump_plugins
-        old_stdout = sys.stdout
-        sys.stdout = StringIO()
-        try:
-            dump_plugins()
-            output = sys.stdout.getvalue()
-        finally:
-            sys.stdout = old_stdout
+def test_dump_plugins(dummy_plugin: str) -> None:
+    # Capture the output of dump_plugins
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        dump_plugins()
+        output = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old_stdout
 
-        # Check if package name is in the output
-        assert DUMMY_PLUGIN_NAME in output
+    # Check if package name is in the output
+    assert dummy_plugin in output
 
 
-def test_plugin_feasibility_report() -> None:
+def test_plugin_feasibility_report(dummy_plugin: str) -> None:
     # Arrange
     test_image = np.random.rand(10, 10)
     expected_error_msg = "missing 1 required positional argument: 'path'"
-    with InstallPackage(package_path=DUMMY_PLUGIN_PATH, package_name=DUMMY_PLUGIN_NAME):
-        # Act
-        actual_output = bioio.plugin_feasibility_report(test_image)
-        # Assert
-        assert actual_output["ArrayLike"].supported is True
-        assert actual_output["ArrayLike"].error is None
-        assert actual_output["dummy-plugin"].supported is False
-        assert expected_error_msg in (actual_output["dummy-plugin"].error or "")
+
+    # Act
+    actual_output = bioio.plugin_feasibility_report(test_image)
+
+    # Assert
+    assert actual_output["ArrayLike"].supported is True
+    assert actual_output["ArrayLike"].error is None
+    assert actual_output[dummy_plugin].supported is False
+    assert expected_error_msg in (actual_output[dummy_plugin].error or "")


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #61 

### Description of Changes

When reading from an S3 protocol our current file system handlers require either explicit credentials passed in or an explicit declaration of an "anonymous" reader. This change makes it so we try to read a file given the current `fs_kwargs` (used by the readers for S3) and if that fails we try to read again as an explicitly "anonymous" reader.

**Additionally** I made it so we only create a text file once and only install the dummy-plugin once because I felt running the tests was rather slow and this sped it up IMO.

### Testing
~Added a unit test, unable to get this to work the S3 file I was provided `s3://allencell/aics/emt_timelapse_dataset/data/3500005548_25_all_cells_mask.ome.zarr`~

bioio-ome-zarr has unreleased changes, when using the newest version of bioio-ome-zarr that is unreleased it works, so I am working on releasing that now but should be GTG after that
