### PR TITLE
add channel selections to writer

### DIFF
--- a/bioio/tests/writers/test_ome_zarr_writer_2.py
+++ b/bioio/tests/writers/test_ome_zarr_writer_2.py
@@ -157,7 +157,7 @@ def test_write_ome_zarr(
     writer.init_store(str(save_uri), shapes, chunk_sizes, im.dtype)
 
     # Write the image
-    writer.write_t_batches_array(im, tbatch=4)
+    writer.write_t_batches_array(im, channels=[], tbatch=4)
 
     # TODO: get this from source image
     physical_scale = {


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves https://github.com/aics-int/ome-zarr-conversion/issues/18

channels had been added as a parameter to the zarr writer at the same time as I was moving it over to bioio. (refer to this commit https://github.com/allen-cell-animated/cellbrowser-tools/pull/14/commits/a9a5b4a5f1c042e44976a7294f86c9cc5c68050a )
This re-adds the channels option to select channels from the source file to be converted.

### Description of Changes

Add a channels list to the relevant writer functions.  writer will only write out the channels that appear in the list (or all channels if the list is empty)