### PR TITLE
Update ome_tiff_writer.py to remove reference to `image_names`

### DIFF
--- a/bioio/writers/ome_tiff_writer.py
+++ b/bioio/writers/ome_tiff_writer.py
@@ -85,7 +85,7 @@ class OmeTiffWriter(Writer):
             Default: None
             If None is given, the list will be generated as a 0-indexed list of strings
             of the form "Channel:image_index:channel_index"
-        image_names: Optional[Union[str, List[Union[str, None]]]]
+        image_name: Optional[Union[str, List[Union[str, None]]]]
             List of strings representing the names of the images
             Default: None
             If None is given, the list will be generated as a 0-indexed list of strings
@@ -158,7 +158,7 @@ class OmeTiffWriter(Writer):
                 if len(image_name) != num_images:
                     raise biob.exceptions.ConflictingArgumentsError(
                         f"OmeTiffWriter received a list of arrays to use as scenes "
-                        f"but the provided list of image_names is of different "
+                        f"but the provided list of image_name is of different "
                         f"length. "
                         f"Number of provided scenes: {num_images}, "
                         f"Number of provided dimension strings: {len(image_name)}"
@@ -167,7 +167,7 @@ class OmeTiffWriter(Writer):
                 if len(physical_pixel_sizes) != num_images:
                     raise biob.exceptions.ConflictingArgumentsError(
                         f"OmeTiffWriter received a list of arrays to use as scenes "
-                        f"but the provided list of image_names is of different "
+                        f"but the provided list of image_name is of different "
                         f"length. "
                         f"Number of provided scenes: {num_images}, "
                         f"Number of provided dimension strings: "


### PR DESCRIPTION
### Link to Relevant Issue

This pull request resolves #

### Description of Changes

Documentation suggests that argument is `image_names` instead of `image_name`. Using `OmeTiffWriter.save(image_names=[str])` silently saves the data without saving the argument to the ome metadata. This fixes updates the documentation so users instead use `OmeTiffWriter.save(image_name=[str])` to avoid this issue.
