### PR TITLE
admin/move-doc-publishing-to-release-cycle

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,16 @@
 name: Documentation
 
+# This will generate the docs on every push to main for logging and tracking purposes
+# But it will only publish the generated docs on a new tag push
+# We may want to move to mkdocs gh-deploy
+# Following: https://github.com/tlambert03/nd2/blob/main/.github/workflows/docs.yml
+
 on:
   push:
     branches:
       - main
+    tags:
+      - "v*"
 
 jobs:
   docs:
@@ -12,8 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # We use https://pypi.org/project/setuptools-scm/ for dynamic lib versioning
-          # Without our tagged versions, it defaults to 0.1.dev*
           fetch-tags: true
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -31,7 +36,10 @@ jobs:
           gitchangelog
           just generate-docs
           touch docs/_build/.nojekyll
+
       - name: Publish Docs
+        # Only publish docs on tag push
+        if: ${{ success() && startsWith(github.ref, 'refs/tags/') }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs/_build/


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #58 

### Description of Changes

<!-- Include a description of the proposed changes. -->

This adds a check to the docs configuration that will build the docs as normal on every push to main (for debugging and tracking) but will only publish the generated docs on git tag pushes.

If this doesn't solve our issue, we may want to consider moving to @tlambert03's setup with `mkdocs`: https://github.com/tlambert03/nd2/blob/main/.github/workflows/docs.yml