### PR TITLE
Switch from ngff-zarr to ome-zarr-models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", 3.11, 3.12]
+        python-version: [3.11, 3.12, 3.13]
         os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
 dependencies = [
@@ -32,10 +32,10 @@ dependencies = [
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
   "imageio[ffmpeg]>=2.11.0,<2.28.0",
-  "ngff-zarr>=0.8.2",
   "numpy>=1.21.0,<2.0.0",
   "ome-types[lxml]>=0.4.0",
   "ome-zarr>=0.6.1",
+  "ome-zarr-models>=0.1.1",
   # This version was revoked from PyPi, but in case of using a stale version
   # or a private package index, this will prevent usage
   "scikit-image!=0.23.0",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

See https://github.com/bioio-devs/bioio-base/issues/25#issuecomment-2575338781, as well as https://github.com/bioio-devs/bioio-ome-zarr/issues/29.

This PR also makes #78 obsolete.

### Description of Changes

<!-- Include a description of the proposed changes. -->
The `ngff-zarr` dependency is replaced by `ome-zarr-models`, mapping the same metadata classes of the OME-NGFF spec.