### PR TITLE
Block using bad scitkit-image

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
   "numpy>=1.21.0,<2.0.0",
   "ome-types[lxml]>=0.4.0",
   "ome-zarr>=0.6.1",
+  # This version was revoked from PyPi, but in case of using a stale version
+  # or a private package index, this will prevent usage
+  "scikit-image!=0.23.0",
   "semver>=3.0.1",
   "tifffile>=2021.8.30",
   "zarr>=2.6.0",


### PR DESCRIPTION
Should resolves #76 which blocks support for Ubuntu 18.04 users by preventing access to this scikit-image