### PR TITLE
allow zarr writer to do incremental writes of single timepoints

### DIFF
--- a/bioio/tests/conftest.py
+++ b/bioio/tests/conftest.py
@@ -57,7 +57,8 @@ def da_random_from_shape(
 
 
 array_constructor = pytest.mark.parametrize(
-    "array_constructor", [np_random_from_shape, da_random_from_shape]
+    "array_constructor",
+    [np_random_from_shape, da_random_from_shape],
 )
 
 DUMMY_PLUGIN_NAME = "dummy-plugin"


### PR DESCRIPTION
### Link to Relevant Issue

Chantelle had a use case where she wanted to write out a time series zarr but could only prepare the source array sequentially, one timestep at a time.  She wanted to use the writer to write sub-arrays incrementally.

### Description of Changes

  So I am adding a toffset parameter to the zarr writer.  The writer will then attempt to write the given time series starting at the given t offset. 

In this way you can call write_t_batches_from_array more than once, in a loop, passing in smaller amounts of t at a time.  

A unit test is added to show how this should be used.  You can just call write_t_batches_array in a loop now.

A future generalization of this could be to pass in even smaller parts of the array and give the writer a tczyx offset of where to start writing the input data.