### PR TITLE
pin the tifffile version so we can release a final 3.9 build 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
   # or a private package index, this will prevent usage
   "scikit-image!=0.23.0",
   "semver>=3.0.1",
-  "tifffile>=2021.8.30",
+  # enumeration constants renamed, breaking bioio
+  "tifffile>=2021.8.30,<2025.2.18", # breaking changes introduced
   "zarr>=2.6.0",
 ]
 


### PR DESCRIPTION
There is another branch with a proper fix; this is the minimum to allow functioning with Python 3.9
Other PR: https://github.com/bioio-devs/bioio/pull/98

Original Issue: https://github.com/bioio-devs/bioio/issues/96

### Description of Changes

Pin tifffile to versions before the enumerations get moved, breaking bioio code.