### PR TITLE
Clarify supported python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", 3.11, 3.12]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
This is a follow-up on https://github.com/bioio-devs/bioio/commit/c5bdbff91124f21775eed01b0200bbb4619c217c, removing Python 3.9 also from the metadata, and adding Python 3.13 to the CI build.