### PR TITLE
feature/standard-metadata

### DIFF
--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -1003,6 +1003,14 @@ class BioImage(biob.image_container.ImageContainer):
         """
         return self.reader.time_interval
 
+    @property
+    def standard_metadata(self) -> biob.standard_metadata.StandardMetadata:
+        """
+        Return the manifest of standard metadata as a dictionary. The possible
+        fields are predefined by the StandardMetadata dataclass.
+        """
+        return self.reader.standard_metadata
+
     def get_mosaic_tile_position(
         self, mosaic_tile_index: int, **kwargs: int
     ) -> Tuple[int, int]:

--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -1006,7 +1006,7 @@ class BioImage(biob.image_container.ImageContainer):
     @property
     def standard_metadata(self) -> biob.standard_metadata.StandardMetadata:
         """
-        Return the manifest of standard metadata as a dictionary. The possible
+        Return a set of standardized metadata. The possible
         fields are predefined by the StandardMetadata dataclass.
         """
         return self.reader.standard_metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "bioio-base>=1.0.5",
+  "bioio-base>=1.0.6",
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
   "imageio[ffmpeg]>=2.11.0,<2.28.0",


### PR DESCRIPTION
### Description 

This pr is a companion PR to https://github.com/bioio-devs/bioio-base/pull/29 adding the standard_metadata property to BioImage so that it can be accessed by top level users.

(tests will fail until base is released adding ImageContainer.standard_metadata)