### PR TITLE
admin/pin-bioio-base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "bioio-base>=1.0.6",
+  "bioio-base==1.0.6", # We always pin a specific version of bioio-base with
+  # each release so that we avoid bioio , bioio-base misalignment.
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
   "imageio[ffmpeg]>=2.11.0,<2.28.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
   "bioio-base==1.0.6", # We always pin a specific version of bioio-base with
-  # each release so that we avoid bioio , bioio-base misalignment.
+  # each release so that we avoid bioio + bioio-base misalignment.
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
   "imageio[ffmpeg]>=2.11.0,<2.28.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "bioio-base==1.0.6", # We always pin a specific version of bioio-base with
+  # We always pin a specific version of bioio-base with
   # each release so that we avoid bioio + bioio-base misalignment.
+  "bioio-base==1.0.6", 
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
   "imageio[ffmpeg]>=2.11.0,<2.28.0",


### PR DESCRIPTION
### Descriptiion 

We have been having issues with releasing new versions of bioio and bioio-base with breaking changes. This allows users to have dependency misalignments. We decided that the simple solution for now is to pin a specific version of bioio-base with every release of bioio. This will ensure that a valid dependency structure is intact.