### PR TITLE
admin/python-support-3.10+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", 3.11, 3.12]
+        python-version: ["3.10", 3.11, 3.12, 3.13]
         os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://github.com/bioio-devs/bioio/actions/workflows/docs.yml/badge.svg)](https://bioio-devs.github.io/bioio)
 [![PyPI version](https://badge.fury.io/py/bioio.svg)](https://badge.fury.io/py/bioio)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
-[![Python 3.9+](https://img.shields.io/badge/python-3.9,3.10,3.11-blue.svg)](https://www.python.org/downloads/release/python-390/)
+[![Python 3.10–3.13](https://img.shields.io/badge/python-3.10--3.13-blue.svg)](https://www.python.org/downloads/)
 
 Image Reading, Metadata Conversion, and Image Writing for Microscopy Images in Pure Python
 

--- a/bioio/tests/dummy-plugin/pyproject.toml
+++ b/bioio/tests/dummy-plugin/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.1.0"
 description = "This is a dummy plugin for testing purposes"
 keywords = []
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "dummy-license" }
 authors = [
   { email = "dummy-email@example.com", name = "dummy-name" },
@@ -20,9 +20,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "bioio-base>=0.2.0",
@@ -95,7 +96,7 @@ show_error_codes = true
 [tool.flake8]
 max-line-length = 88
 ignore = "E203,E402,W291,W503"
-min-python-version = "3.9.0"
+min-python-version = "3.10.0"
 per-file-ignores = [
   "__init__.py:F401",
 ]

--- a/bioio/writers/ome_zarr_writer_2.py
+++ b/bioio/writers/ome_zarr_writer_2.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from math import prod
 from typing import Any, List, Tuple, Union
 
@@ -8,7 +8,12 @@ import numcodecs
 import numpy as np
 import skimage.transform
 import zarr
-from ngff_zarr.zarr_metadata import Axis, Dataset, Metadata, Scale, Translation
+from ome_zarr_models.v04.axes import Axis
+from ome_zarr_models.v04.coordinate_transformations import (
+    VectorScale,
+    VectorTranslation,
+)
+from ome_zarr_models.v04.multiscales import Dataset, Multiscale
 from zarr.storage import DirectoryStore, FSStore, default_compressor
 
 from bioio import BioImage
@@ -659,19 +664,23 @@ class OmeZarrWriter:
                 # TODO handle optional translations e.g. xy stage position,
                 # start time etc
                 translation.append(0.0)
-            coordinateTransformations = [Scale(scale), Translation(translation)]
+            coordinateTransformations = (
+                VectorScale(type="scale", scale=scale),
+                VectorTranslation(type="translation", translation=translation),
+            )
             dataset = Dataset(
                 path=path, coordinateTransformations=coordinateTransformations
             )
             datasets.append(dataset)
-        metadata = Metadata(
+        metadata = Multiscale(
+            version=OME_NGFF_VERSION,
             axes=axes,
             datasets=datasets,
             name="/",
             coordinateTransformations=None,
         )
 
-        metadata_dict = asdict(metadata)
+        metadata_dict = metadata.model_dump()
         metadata_dict = _pop_metadata_optionals(metadata_dict)
 
         # get the total shape as dict:

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -23,7 +23,7 @@ Image Reading, Metadata Conversion, and Image Writing for Microscopy Images in P
 
 ## Installation
 
-BioIO requires Python version 3.9 and up
+BioIO requires Python version 3.10 and up
 
 **Stable Release:** `pip install bioio`<br>
 **Development Head:** `pip install git+https://github.com/bioio-devs/bioio.git`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,9 @@ dependencies = [
   "numpy>=1.21.0",
   "ome-types[lxml]>=0.4.0",
   "ome-zarr>=0.6.1",
-  "ome-zarr-models>=0.1.1",
+  # Use ngff-zarr for Python 3.10 or lower and ome-zarr-models for Python 3.11 or higher.
+  'ngff-zarr>=0.8.2,<0.9.1; python_version < "3.11"',
+  'ome-zarr-models>=0.1.1; python_version >= "3.11"',
   # This version was revoked from PyPi, but in case of using a stale version
   # or a private package index, this will prevent usage
   "scikit-image!=0.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,10 @@ authors = [
 classifiers = [
   "Development Status :: 4 - Beta",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
 dependencies = [
@@ -33,17 +34,16 @@ dependencies = [
   "bioio-base==1.0.6", 
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
-  "imageio[ffmpeg]>=2.11.0,<2.28.0",
-  "ngff-zarr>=0.8.2,<0.9.1",
-  "numpy>=1.21.0,<2.0.0",
+  "imageio[ffmpeg]>=2.11.0",
+  "numpy>=1.21.0",
   "ome-types[lxml]>=0.4.0",
   "ome-zarr>=0.6.1",
+  "ome-zarr-models>=0.1.1",
   # This version was revoked from PyPi, but in case of using a stale version
   # or a private package index, this will prevent usage
   "scikit-image!=0.23.0",
   "semver>=3.0.1",
-  # enumeration constants renamed, breaking bioio
-  "tifffile>=2021.8.30,<2025.2.18", # breaking changes introduced
+  "tifffile>=2021.8.30",
   "zarr>=2.6.0",
 ]
 
@@ -136,7 +136,7 @@ show_error_codes = true
 [tool.flake8]
 max-line-length = 88
 ignore = "E203,E402,W291,W503"
-min-python-version = "3.9.0"
+min-python-version = "3.10.0"
 per-file-ignores = [
   "__init__.py:F401",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "ome-types[lxml]>=0.4.0",
   "ome-zarr>=0.6.1",
   # Use ngff-zarr for Python 3.10 or lower and ome-zarr-models for Python 3.11 or higher.
-  'ngff-zarr>=0.8.2,<0.9.1; python_version < "3.11"',
+  'ngff-zarr>=0.8.2; python_version < "3.11"',
   'ome-zarr-models>=0.1.1; python_version >= "3.11"',
   # This version was revoked from PyPi, but in case of using a stale version
   # or a private package index, this will prevent usage


### PR DESCRIPTION
### Description

This PR does a few things all centered around updating our supported python versions to 3.10-3.13. It resolves #108, #104, #70, kind of resolves #10 maybe? And includes the changes from #105 and #80.

1.) Remove all past refrences to 3.9
2.) unpins `imageio[ffmpeg]`, `numpy`, and `tifffile`
3.) Conditionally resolve 'ome_zarr_writer_2.py` dependencies to support all python versions 
4.) define specific dependencies per python version 
5.) update the time series writer tests which were broken and out of date. (this could probably be another PR but was trying to go green)