### PR TITLE
admin/pin-numcodecs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "imageio[ffmpeg]>=2.11.0,<2.28.0",
   "ngff-zarr>=0.8.2,<0.9.1",
   "numpy>=1.21.0,<2.0.0",
+  "numcodecs<0.15.1",
   "ome-types[lxml]>=0.4.0",
   "ome-zarr>=0.6.1",
   # This version was revoked from PyPi, but in case of using a stale version


### PR DESCRIPTION
### Description

The purpose of this PR is to pin git `numcodecs` a dependency of `zarr` which breaks with its newest release. Resolves #115 