### PR TITLE
Bugfix: Remove unnecessary bioio-czi dependency that breaks CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ lint = [
   "pre-commit>=2.20.0",
 ]
 test = [
-  "bioio-czi @ git+https://github.com/bioio-devs/bioio-czi.git@main",
   "coverage>=5.1",
   "pytest>=5.4.3",
   "pytest-cov>=2.9.0",


### PR DESCRIPTION
In #107 I added bioio-czi to the test dependencies to enable the initial way I proposed testing bioio & bioio-czi together. Ultimately, we went a different route and bioio-czi is not needed in the test dependencies, so this line can be removed.

Moreover, the way this bioio-czi dependency is defined appears to be unacceptable to pypi and [breaks our release job](https://github.com/bioio-devs/bioio/actions/runs/14718383796/job/41307402793). Merging this PR should help allow bioio to be released.