### PR TITLE
Bugfix: OME ZARR v2 writer throws error

### DIFF
--- a/bioio/writers/ome_zarr_writer_2.py
+++ b/bioio/writers/ome_zarr_writer_2.py
@@ -150,7 +150,10 @@ def _pop_metadata_optionals(metadata_dict: dict) -> dict:
         if ax["unit"] is None:
             ax.pop("unit")
 
-    if metadata_dict["coordinateTransformations"] is None:
+    if (
+        hasattr(metadata_dict, "coordinateTransformations")
+        and metadata_dict["coordinateTransformations"] is None
+    ):
         metadata_dict.pop("coordinateTransformations")
 
     return metadata_dict


### PR DESCRIPTION
# Release strategy
With this PR, I propose a more advanced branching release strategy for bioio than we have previously used. This PR fixes a bug in the latest bioio release: v1.6.1, but other changes committed to bioio's main branch (1) create a major version bump and (2) are not ready to be released yet. The fix in this PR could be released on its own as v1.6.2. To do so, we would perpetually maintain a release branch named `v1.6` that neither merges into main nor gets main merged into it, and we would do releases of v1.6.* versions from this branch. I have already taken the liberty of creating this new branch to use as the base branch for this PR. 

If we are okay with this release strategy, we should communicate it to the bioio developers and set branch protections for release branches like v1.6.

# Changes
Before attempting to remove `coordinate_transforms` from `metadata_dict`, check that it is not already removed.

Resolves #136 

# Testing
With this change, I can successfully write a v2 OME ZARR.