### PR TITLE
update bioio-base class docs

### DIFF
--- a/bioio/__init__.py
+++ b/bioio/__init__.py
@@ -20,17 +20,17 @@ try:
 except ImportError:
     # Safe fallback during install/docs build
     _fallback_symbols = [
-        "StandardMetadata",
-        "Writer",
+        "ArrayLike",
         "DimensionNames",
         "Dimensions",
-        "ArrayLike",
-        "MetaArrayLike",
-        "Scale",
-        "PhysicalPixelSizes",
         "ImageLike",
-        "TimeInterval",
+        "MetaArrayLike",
         "PathLike",
+        "PhysicalPixelSizes",
+        "Scale",
+        "StandardMetadata",
+        "TimeInterval",
+        "Writer",
     ]
     globals().update({name: None for name in _fallback_symbols})
 

--- a/bioio/__init__.py
+++ b/bioio/__init__.py
@@ -4,6 +4,37 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
+try:
+    from bioio_base.dimensions import DimensionNames, Dimensions
+    from bioio_base.standard_metadata import StandardMetadata
+    from bioio_base.types import (
+        ArrayLike,
+        ImageLike,
+        MetaArrayLike,
+        PathLike,
+        PhysicalPixelSizes,
+        Scale,
+        TimeInterval,
+    )
+    from bioio_base.writer import Writer
+except ImportError:
+    # Safe fallback during install/docs build
+    _fallback_symbols = [
+        "StandardMetadata",
+        "Writer",
+        "DimensionNames",
+        "Dimensions",
+        "ArrayLike",
+        "MetaArrayLike",
+        "Scale",
+        "PhysicalPixelSizes",
+        "ImageLike",
+        "TimeInterval",
+        "PathLike",
+    ]
+    globals().update({name: None for name in _fallback_symbols})
+
+
 from .bio_image import BioImage
 from .plugins import plugin_feasibility_report
 
@@ -16,6 +47,17 @@ __author__ = "Eva Maxfield Brown, Dan Toloudis, BioIO Contributors"
 __email__ = "evamaxfieldbrown@gmail.com, danielt@alleninstitute.org"
 
 __all__ = [
+    "ArrayLike",
     "BioImage",
+    "DimensionNames",
+    "Dimensions",
+    "ImageLike",
+    "MetaArrayLike",
+    "PathLike",
+    "PhysicalPixelSizes",
+    "Scale",
+    "StandardMetadata",
+    "TimeInterval",
+    "Writer",
     "plugin_feasibility_report",
 ]

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,0 +1,51 @@
+API Reference
+=============
+
+This page documents the public API of the `bioio` package.
+
+.. currentmodule:: bioio
+
+Core Classes
+------------
+
+.. autosummary::
+   :toctree: generated/
+   :recursive:
+
+   BioImage
+   StandardMetadata
+   Writer
+
+Types and Aliases
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+   :recursive:
+
+   ArrayLike
+   MetaArrayLike
+   Scale
+   TimeInterval
+   ImageLike
+   PathLike
+   PhysicalPixelSizes
+
+Enums and Dimensions
+--------------------
+
+.. autosummary::
+   :toctree: generated/
+   :recursive:
+
+   DimensionNames
+   Dimensions
+
+Utilities
+---------
+
+.. autosummary::
+   :toctree: generated/
+   :recursive:
+
+   plugin_feasibility_report

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ numpydoc_show_class_members = False
 sphinx_tabs_disable_tab_closing = True
 
 autoclass_content = "both"
+autodoc_mock_imports = ["bioio_base"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ Welcome to bioio's documentation!
 
    Overview <OVERVIEW>
    Installation <INSTALLATION>
-   Full API Reference <modules>
+   Full API Reference <api_reference>
    Developer Resources <developer_resources>
    Changelog <CHANGELOG>
    AICSImageIO Migration <MIGRATION>


### PR DESCRIPTION
The purpose of this PR is to pull in the Core Classes, Types and Aliases from `bioio_base` so that we can document them within `bioio`. This PR resolves #134 , #45  and #122. (once bioio is released with bioio-base 3.0.0).