### PR TITLE
DOCS: fix links to reader installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ ENV/
 
 # VSCode
 .vscode
+docs/generated

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -4,8 +4,8 @@
 
 Very little about the API has changed between `aicsimageio` version 4.0.0+ and `bioio`.  The API is largely the same with the biggest differences being:
 * You use a different Python package (`bioio` instead of `aicsimageio`)
-    * **Important** - See the [Reader Installation Instructions](https://github.com/bioio-devs/bioio/main/README.md#reader-installation) for which additional packages (`bioio` plug-ins) you'll need to support the files you want to interact with
-* Reader plugins are separate packages that are installed separately.  OmeTiffReader and OmeZarrReader are preinstalled with the default distribution of bioio.
+    * **Important** - See the [Reader Installation Instructions](https://bioio-devs.github.io/bioio/OVERVIEW.html#reader-installation) for which additional packages (`bioio` plug-ins) you'll need to support the files you want to interact with
+* Reader plugins are separate packages that are installed separately.  `OmeTiffReader` and `OmeZarrReader` are preinstalled with the default distribution of `bioio`.
 * The main class exported was renamed from `AICSImage` to `BioImage`
 
 Example of **OLD** code using `aicsimageio`
@@ -32,7 +32,7 @@ A few reasons:
 * Licensing is easier to understand and manage with `bioio` since each file reader is installed separately.
 * Fewer dependencies are necessary for users that require only a subset of the total available readers.
 * Readers can evolve independently of each other. For example (totally hypothetical), if `bioio-czi` (AKA the CZI reader) needs to start using `dask` version `4.0.0+`, but `bioio-tifffile` (AKA the TIFF reader) needs `dask` version `3.4.0-3.9.0` then we can upgrade `bioio-czi` without conflicting with `bioio-tifffile`.
-* Community Reader development is now made easier.  You can write and maintain 
+* Community Reader development is now made easier.  You can write and maintain
 your own custom reader without having to submit it to the core bioio package.  We always encourage publicizing useful readers for the imaging community at large.
 * `aicsimageio` will be moving into "maintenance" only mode, meaning only critical bugfixes will be made to the codebase.  `bioio` will be where new features / support for new version of Python are made.
 

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -7,7 +7,7 @@ Image Reading, Metadata Conversion, and Image Writing for Microscopy Images in P
 ## Features
 
 - Image Reading
-    - BioIO can read many various image formats (ex. `OME-TIFF`, `PNG`,  `ND2`), but only when paired with the appropriate plug-in for the image format. See [Reader Installation](#id1) for a full list of the currently supported image formats as well as how to install them.
+    - BioIO can read many various image formats (ex. `OME-TIFF`, `PNG`,  `ND2`), but only when paired with the appropriate plug-in for the image format. See [Reader Installation](#reader-installation) for a full list of the currently supported image formats as well as how to install them.
 - Image Writing
     - Supports writing metadata and imaging data for:
         - `OME-TIFF`


### PR DESCRIPTION
These links were broken on the current docs page


