### PR TITLE
add token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
   # Check tests pass on multiple Python and OS combinations
   test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description 

The purpose of this PR is to resolve #81 and fix codecov uploads. It looks like we just currently block the upload via permissions. Theres two fixes here. 1) add the token to uploads 2) change the permissions in codecov.

I opted for `1`


TODO:

- [ ] Add the GH secret to org 