### PR TITLE
remove mac-os 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", 3.11, 3.12, 3.13]
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Description 

We added mac-os-13 to cover specific failures, the runner has been depreciated so we need to remove it.  Resolves #165 