### PR TITLE
allow lint for 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,6 @@ jobs:
   # Shared lint workflow from bioio-base
   lint:
     uses: bioio-devs/bioio-base/.github/workflows/shared_lint.yml@main
-    with:
-      lint_python_version: "3.11"
 
   # Publish to PyPI if test, lint, and manifest checks passed
   publish:


### PR DESCRIPTION
Trivial extension of the shared CI to use the default (3.13) python version

### Link to Relevant Issue

[This pull request resolves #](https://github.com/bioio-devs/bioio-base/issues/55)

### Description of Changes

No longer use the version parameter for CI lint.
