### PR TITLE
Feature/shared ci no codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,6 @@ jobs:
       contents: read
       id-token: write
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
-    with:
-      install_ffmpeg_macos: true
 
   # Shared lint workflow from bioio-base
   lint:


### PR DESCRIPTION
Turns out CI runs just fine without the extra flags.