### PR TITLE
Chore/modernize dev tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,23 @@
 files: bioio
 repos:
     - repo: https://github.com/PyCQA/isort
-      rev: 5.12.0
+      rev: 8.0.1
       hooks:
           - id: isort
 
     - repo: https://github.com/myint/autoflake
-      rev: v2.2.0
+      rev: v2.3.3
       hooks:
           - id: autoflake
             args: ["--in-place", "--remove-all-unused-imports"]
 
     - repo: https://github.com/psf/black
-      rev: 23.3.0
+      rev: 26.3.1
       hooks:
           - id: black
 
     - repo: https://github.com/PyCQA/flake8
-      rev: 6.1.0
+      rev: 7.3.0
       hooks:
           - id: flake8
             additional_dependencies:
@@ -25,6 +25,6 @@ repos:
                 - flake8-pyprojecttoml
 
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.4.1
+      rev: v1.19.1
       hooks:
           - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,11 @@
 files: bioio
 repos:
-    - repo: https://github.com/PyCQA/isort
-      rev: 8.0.1
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.11.2
       hooks:
-          - id: isort
-
-    - repo: https://github.com/myint/autoflake
-      rev: v2.3.3
-      hooks:
-          - id: autoflake
-            args: ["--in-place", "--remove-all-unused-imports"]
-
-    - repo: https://github.com/psf/black
-      rev: 26.3.1
-      hooks:
-          - id: black
-
-    - repo: https://github.com/PyCQA/flake8
-      rev: 7.3.0
-      hooks:
-          - id: flake8
-            additional_dependencies:
-                - flake8-typing-imports>=1.9.0
-                - flake8-pyprojecttoml
+          - id: ruff
+            args: ["--fix"]
+          - id: ruff-format
 
     - repo: https://github.com/pre-commit/mirrors-mypy
       rev: v1.19.1

--- a/Justfile
+++ b/Justfile
@@ -31,7 +31,7 @@ lint:
 
 # run tests
 test:
-	pytest --cov-report xml --cov-report html --cov=bioio bioio/tests
+	pytest
 
 # run lint and then run tests
 build:

--- a/bioio/array_like_reader.py
+++ b/bioio/array_like_reader.py
@@ -316,9 +316,9 @@ class ArrayLikeReader(Reader):
                     if DimensionNames.Channel not in this_scene.coords:
                         # Use provided
                         if this_scene_channel_names is not None:
-                            this_scene.coords[
-                                DimensionNames.Channel
-                            ] = this_scene_channel_names
+                            this_scene.coords[DimensionNames.Channel] = (
+                                this_scene_channel_names
+                            )
 
                         # Generate
                         else:
@@ -331,9 +331,9 @@ class ArrayLikeReader(Reader):
                                     )
                                 )
 
-                            this_scene.coords[
-                                DimensionNames.Channel
-                            ] = set_channel_names
+                            this_scene.coords[DimensionNames.Channel] = (
+                                set_channel_names
+                            )
 
                 # Provided None, generate
                 if this_scene_channel_names is None:

--- a/bioio/array_like_reader.py
+++ b/bioio/array_like_reader.py
@@ -316,9 +316,9 @@ class ArrayLikeReader(Reader):
                     if DimensionNames.Channel not in this_scene.coords:
                         # Use provided
                         if this_scene_channel_names is not None:
-                            this_scene.coords[DimensionNames.Channel] = (
-                                this_scene_channel_names
-                            )
+                            this_scene.coords[
+                                DimensionNames.Channel
+                            ] = this_scene_channel_names
 
                         # Generate
                         else:
@@ -331,9 +331,9 @@ class ArrayLikeReader(Reader):
                                     )
                                 )
 
-                            this_scene.coords[DimensionNames.Channel] = (
-                                set_channel_names
-                            )
+                            this_scene.coords[
+                                DimensionNames.Channel
+                            ] = set_channel_names
 
                 # Provided None, generate
                 if this_scene_channel_names is None:

--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -1318,12 +1318,7 @@ class BioImage(biob.image_container.ImageContainer):
             )
 
         reader_name = self._reader.name if self._reader is not None else "None"
-        return (
-            f"<BioImage ["
-            f"reader: {reader_name}, "
-            f"image-in-memory: {in_memory}"
-            f"]>"
-        )
+        return f"<BioImage [reader: {reader_name}, image-in-memory: {in_memory}]>"
 
     def __repr__(self) -> str:
         return str(self)

--- a/bioio/bio_image.py
+++ b/bioio/bio_image.py
@@ -1318,7 +1318,12 @@ class BioImage(biob.image_container.ImageContainer):
             )
 
         reader_name = self._reader.name if self._reader is not None else "None"
-        return f"<BioImage [reader: {reader_name}, image-in-memory: {in_memory}]>"
+        return (
+            f"<BioImage ["
+            f"reader: {reader_name}, "
+            f"image-in-memory: {in_memory}"
+            f"]>"
+        )
 
     def __repr__(self) -> str:
         return str(self)

--- a/bioio/plugins.py
+++ b/bioio/plugins.py
@@ -350,9 +350,9 @@ def dump_plugins(use_cache: bool = True) -> None:
             author = dist.metadata.json.get("author")
             license = dist.metadata.json.get("license")
 
-            print(f"  Author  : {author if author is not None else 'Not Specified'}")
+            print(f'  Author  : {author if author is not None else "Not Specified"}')
             print(f"  Version : {dist.version}")
-            print(f"  License : {license if license is not None else 'Not Specified'}")
+            print(f'  License : {license if license is not None else "Not Specified"}')
 
             # Unpack files
             files = dist.files

--- a/bioio/plugins.py
+++ b/bioio/plugins.py
@@ -350,9 +350,9 @@ def dump_plugins(use_cache: bool = True) -> None:
             author = dist.metadata.json.get("author")
             license = dist.metadata.json.get("license")
 
-            print(f'  Author  : {author if author is not None else "Not Specified"}')
+            print(f"  Author  : {author if author is not None else 'Not Specified'}")
             print(f"  Version : {dist.version}")
-            print(f'  License : {license if license is not None else "Not Specified"}')
+            print(f"  License : {license if license is not None else 'Not Specified'}")
 
             # Unpack files
             files = dist.files

--- a/bioio/tests/helpers/mock_reader.py
+++ b/bioio/tests/helpers/mock_reader.py
@@ -58,7 +58,8 @@ class PluginFactoryFixture(Protocol):
     `TestPluginSpec` and returns the created EntryPoint objects.
     """
 
-    def __call__(self, specs: Iterable[TestPluginSpec]) -> list[EntryPoint]: ...
+    def __call__(self, specs: Iterable[TestPluginSpec]) -> list[EntryPoint]:
+        ...
 
 
 # -----------------------------------------------------------------------------

--- a/bioio/tests/helpers/mock_reader.py
+++ b/bioio/tests/helpers/mock_reader.py
@@ -58,8 +58,7 @@ class PluginFactoryFixture(Protocol):
     `TestPluginSpec` and returns the created EntryPoint objects.
     """
 
-    def __call__(self, specs: Iterable[TestPluginSpec]) -> list[EntryPoint]:
-        ...
+    def __call__(self, specs: Iterable[TestPluginSpec]) -> list[EntryPoint]: ...
 
 
 # -----------------------------------------------------------------------------

--- a/bioio/tests/helpers/mock_writer.py
+++ b/bioio/tests/helpers/mock_writer.py
@@ -47,7 +47,8 @@ class WriterFactoryFixture(Protocol):
     `TestWriterSpec` and returns the created EntryPoint objects.
     """
 
-    def __call__(self, specs: Iterable[TestWriterSpec]) -> List[EntryPoint]: ...
+    def __call__(self, specs: Iterable[TestWriterSpec]) -> List[EntryPoint]:
+        ...
 
 
 # -----------------------------------------------------------------------------

--- a/bioio/tests/helpers/mock_writer.py
+++ b/bioio/tests/helpers/mock_writer.py
@@ -47,8 +47,7 @@ class WriterFactoryFixture(Protocol):
     `TestWriterSpec` and returns the created EntryPoint objects.
     """
 
-    def __call__(self, specs: Iterable[TestWriterSpec]) -> List[EntryPoint]:
-        ...
+    def __call__(self, specs: Iterable[TestWriterSpec]) -> List[EntryPoint]: ...
 
 
 # -----------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ exclude = ["*docs/*", "*tests/*"]
 # tools
 [tool.black]
 line-length = 88
+target-version = ["py310", "py311", "py312", "py313"]
 
 [tool.isort]
 ensure_newline_before_comments = true
@@ -125,7 +126,7 @@ show_error_codes = true
 # https://gitlab.com/durko/flake8-pyprojecttoml
 [tool.flake8]
 max-line-length = 88
-ignore = "E203,E402,W291,W503"
+ignore = "E203,E402,E704,W291,W503"
 min-python-version = "3.10.0"
 per-file-ignores = [
   "__init__.py:F401",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,18 +88,20 @@ exclude = ["*docs/*", "*tests/*"]
 "*" = ["*.yaml", "py.typed"]
 
 # tools
-[tool.black]
+[tool.ruff]
 line-length = 88
-target-version = ["py310", "py311", "py312", "py313"]
+target-version = "py310"
 
-[tool.isort]
-ensure_newline_before_comments = true
-force_grid_wrap = 0
-include_trailing_comma = true
-line_length = 88
-multi_line_output = 3
-profile = "black"
-use_parentheses = true
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = ["E402"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
 
 # https://github.com/mgedmin/check-manifest#configuration
 [tool.check-manifest]
@@ -126,12 +128,3 @@ disallow_untyped_defs = true
 check_untyped_defs = true
 show_error_codes = true
 
-# https://flake8.pycqa.org/en/latest/user/options.html
-# https://gitlab.com/durko/flake8-pyprojecttoml
-[tool.flake8]
-max-line-length = 88
-ignore = "E203,E402,E704,W291,W503"
-min-python-version = "3.10.0"
-per-file-ignores = [
-  "__init__.py:F401",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,10 @@ ignore = [
   "*tests/**",
 ]
 
+[tool.pytest.ini_options]
+addopts = "--cov=bioio --cov-report=xml --cov-report=html"
+testpaths = ["bioio/tests"]
+
 [tool.mypy]
 files = "bioio/*.py"
 ignore_missing_imports = true


### PR DESCRIPTION
## Description 
This Pr is mostly me experimenting with a new development method and utilizing Claude as much as I can. I was aware that some of our dev tools were out of date so I was doing an ai review of our linting. This led me to the recommendation of Ruff. We have an open ticket for #50 to use Ruff and I thought this might be an opportunity to upgrade. This PR is completely AI generated and all commits and comments were made with Claude as an experiment.  


## Summary

Three developer tooling improvements to modernize the project's dev workflow:

**1. Update pre-commit hook versions**
All hooks were significantly out of date. Ran `pre-commit autoupdate` to bring them current: `black` 23→26, `mypy` 1.4→1.19, `isort` 5.12→8, `flake8` 6→7, `autoflake` 2.2→2.3. Also pinned black's `target-version` to py310–py313 to match `requires-python`.

**2. Move pytest config into pyproject.toml**
Test runner arguments were only defined in the `Justfile`. Added `[tool.pytest.ini_options]` to `pyproject.toml` so the config is picked up automatically by any test runner (IDEs, CI, etc.), not just `just test`.

**3. Replace black + isort + flake8 + autoflake with ruff**
Consolidates four separate linting/formatting tools into a single `ruff` hook. Ruff is faster, requires less config, and is now the de facto standard in the Python ecosystem. The `[tool.black]`, `[tool.isort]`, and `[tool.flake8]` config sections in `pyproject.toml` are replaced by a single `[tool.ruff]` block.

## Test plan

- [x] `just lint` passes (ruff + mypy clean)
- [x] `just test` passes (112 tests: 102 passed, 10 xfailed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)