### PR TITLE
bump base 3.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dynamic = ["version"]
 dependencies = [
   # We always pin a specific version of bioio-base with
   # each release so that we avoid bioio + bioio-base misalignment.
-  "bioio-base~=3.4.0",
+  "bioio-base~=3.5.0",
   "dask[array]>=2021.4.1",
   "numpy>=1.21.0",
   "ome-types[lxml]>=0.4.0",


### PR DESCRIPTION
## Description

We released `bioio-base==3.5.0` which contains 2 additional `standard_metadata` fields. In order to properly release this bump of base we need to do a release of bioio 