### PR TITLE
Add CITATION.cff and citation section to README

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+title: BioIO
+message: >-
+  If you use BioIO in your research, please cite it using
+  this metadata. This applies to all bioio plugin packages —
+  cite the core bioio ecosystem, not individual plugins.
+type: software
+authors:
+  - name: BioIO Contributors
+repository-code: https://github.com/bioio-devs/bioio
+url: https://bioio-devs.github.io/bioio
+license: BSD-3-Clause
+version: 3.5.0
+date-released: "2026-07-30"
+abstract: >-
+  BioIO is a plugin-based Python library for reading, writing,
+  and converting microscopy image data. It provides a unified
+  interface across a wide variety of image formats through a
+  modular ecosystem of reader and writer plugins built on bioio-base.
+keywords:
+  - microscopy
+  - bioimaging
+  - image-io
+  - python
+  - plugins
+  - ome

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,6 @@ authors:
 repository-code: https://github.com/bioio-devs/bioio
 url: https://bioio-devs.github.io/bioio
 license: BSD-3-Clause
-version: 3.5.0
-date-released: "2026-07-30"
 abstract: >-
   BioIO is a plugin-based Python library for reading, writing,
   and converting microscopy image data. It provides a unified
@@ -22,5 +20,4 @@ keywords:
   - bioimaging
   - image-io
   - python
-  - plugins
   - ome

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 title: BioIO
 message: >-
   If you use BioIO in your research, please cite it using
-  this metadata. This applies to all bioio plugin packages —
-  cite the core bioio ecosystem, not individual plugins.
+  this metadata or the DOI. Note that plugins have their
+  own licenses.
 type: software
 authors:
   - name: BioIO Contributors
@@ -18,6 +18,9 @@ abstract: >-
 keywords:
   - microscopy
   - bioimaging
-  - image-io
-  - python
-  - ome
+  - image I/O
+  - file formats
+  - lazy loading
+  - dask
+  - Python
+  - OME

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include bioio *.toml
+include CITATION.cff
 exclude */tests  # Not needed for users

--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ If you use BioIO in your research, please cite the core bioio package. This appl
   title     = {{BioIO}},
   url       = {https://github.com/bioio-devs/bioio},
   doi       = {10.5281/zenodo.XXXXXXX},
-  version   = {3.5.0},
-  year      = {2026},
+  year      = {2023},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ OmeTiffWriter.save(image, "file.ome.tiff", dim_order="ZCYX")
 
 ## Citation
 
-If you use BioIO in your research, please cite the core bioio package. This applies whether you are using `bioio` directly or any bioio plugin (`bioio-czi`, `bioio-tifffile`, etc.) — plugins do not require separate citations.
+If you use BioIO in your research, please cite the core bioio package via the DOI.
 
 [![DOI](https://zenodo.org/badge/524159605.svg)](https://zenodo.org/badge/latestdoi/524159605)
 
@@ -114,6 +114,8 @@ If you use BioIO in your research, please cite the core bioio package. This appl
 ```
 
 For other citation formats, use the **Cite this repository** button at the top of this page (powered by the `CITATION.cff` file).
+
+*Note: BioIO's various plugins each carry their own license.*
 
 ## Issues
 [_Click here to view all open issues in bioio-devs organization at once_](https://github.com/search?q=user%3Abioio-devs+is%3Aissue+is%3Aopen&type=issues&ref=advsearch)

--- a/README.md
+++ b/README.md
@@ -95,5 +95,24 @@ image = np.random.rand(10, 3, 1024, 2048)
 OmeTiffWriter.save(image, "file.ome.tiff", dim_order="ZCYX")
 ```
 
+## Citation
+
+If you use BioIO in your research, please cite the core bioio package. This applies whether you are using `bioio` directly or any bioio plugin (`bioio-czi`, `bioio-tifffile`, etc.) — plugins do not require separate citations.
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)
+
+```bibtex
+@software{bioio,
+  author    = {BioIO Contributors},
+  title     = {{BioIO}},
+  url       = {https://github.com/bioio-devs/bioio},
+  doi       = {10.5281/zenodo.XXXXXXX},
+  version   = {3.5.0},
+  year      = {2026},
+}
+```
+
+For other citation formats, use the **Cite this repository** button at the top of this page (powered by the `CITATION.cff` file).
+
 ## Issues
 [_Click here to view all open issues in bioio-devs organization at once_](https://github.com/search?q=user%3Abioio-devs+is%3Aissue+is%3Aopen&type=issues&ref=advsearch)

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ OmeTiffWriter.save(image, "file.ome.tiff", dim_order="ZCYX")
 
 If you use BioIO in your research, please cite the core bioio package. This applies whether you are using `bioio` directly or any bioio plugin (`bioio-czi`, `bioio-tifffile`, etc.) — plugins do not require separate citations.
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.XXXXXXX.svg)](https://doi.org/10.5281/zenodo.XXXXXXX)
+[![DOI](https://zenodo.org/badge/524159605.svg)](https://zenodo.org/badge/latestdoi/524159605)
 
 ```bibtex
 @software{bioio,


### PR DESCRIPTION
## Summary

- Adds `CITATION.cff` so GitHub surfaces a "Cite this repository" button and tools like Zotero can auto-import citation metadata
- Adds a `## Citation` section to `README.md` with a DOI badge and BibTeX block
- Citation strategy: users cite the core `bioio` package regardless of which plugin they used — plugins do not require separate citations

## TODOs before merging

- [x] Zenodo generates a DOI on the next release — we will need to fix tine doi link in the bibtex with a second PR (but dont need to do a release then)
- [x] Finalize authors in `CITATION.cff` and BibTeX block (currently `BioIO Contributors` placeholder)
- [x] Add the short citation block to plugin READMEs and `bioio-base`

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)